### PR TITLE
Remove node method not-supported on IE

### DIFF
--- a/cookies-enabler.js
+++ b/cookies-enabler.js
@@ -344,8 +344,8 @@ window.COOKIES_ENABLER = window.COOKIES_ENABLER || (function () {
 
             for (i = n - 1; i >= 0; i--){
 
-                iframePlaceholders[i].remove();
-
+                iframePlaceholders[i].parentNode.removeChild(iframePlaceholders[i]);
+                
             }
 
         }


### PR DESCRIPTION
Il metodo Node.remove() non è supportato prima di edge. Usare removeChild().
