### PR TITLE
Added functionality to add ce-cookie on wildcard subdomains

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ clickOutside: false,
 
 cookieName: 'ce-cookie',
 cookieDuration: '365',
+wildcardDomain: false,
 
 iframesPlaceholder: true,
 iframesPlaceholderHTML:
@@ -187,6 +188,11 @@ onDisable: function(){
 
 }
 ```
+
+#### Subdomains
+
+You can enable this cookie to be saved across all your subdomains by enabling the ```wildcardDomain``` option.
+
 
 #### Problematic Scripts
 

--- a/cookies-enabler.js
+++ b/cookies-enabler.js
@@ -297,7 +297,7 @@ window.COOKIES_ENABLER = window.COOKIES_ENABLER || (function () {
                 expires = "";
             }
             
-            host = location.host;
+            host = location.hostname;
             // Means localhost or that the user does not want to enable cookies for all subdomains
             if(host.split('.') === 1 || !opts.wildcardDomain) {
                 document.cookie = opts.cookieName +"="+ value+expires +"; path=/";
@@ -307,6 +307,7 @@ window.COOKIES_ENABLER = window.COOKIES_ENABLER || (function () {
                 domainParts = host.split('.');
                 domainParts.shift();
                 domain = '.' + domainParts.join('.');
+                
                 document.cookie = opts.cookieName +"="+ value+expires +"; path=/; domain="+domain;
                 
                 // Check if we managed to set the cookie, if not we where on a top-domain

--- a/demo/demo.html
+++ b/demo/demo.html
@@ -106,6 +106,7 @@
 
             cookieName: 'ce-cookie',
             cookieDuration: '365',
+            wildcardDomain: false,
 
             iframesPlaceholder: true,
             iframesPlaceholderHTML:


### PR DESCRIPTION
I had this problem myself that we have a lot of different subdomains where we currently use this tool on. 
And got annoyed after a while that I got the same popup over and over again since I was only accepting cookies the current domain I was on. 

So I added an option called wildcardDomain true/false, defaults to false. Maybe the strangest part that needs some explaining is when we try to set the cookie and then check if it stuck. Thats because some top domains have multiple parts e.g foo.co.uk so instead we let the browser handle the top level domain stuff for us.

Maybe the option name could be worked a little bit on? WildcardDomain does not feel 100%, but I didn't come up with anything better.
